### PR TITLE
updated latest Oracle Linux image version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "instance_os" {
 
 variable "linux_os_version" {
   description = "Operating system version for all Linux instances"
-  default     = "7.8"
+  default     = "7.9"
 }
 
 variable "instance_shape" {


### PR DESCRIPTION
Version 7.8 created an invalid index error when running `terraform plan`; Updated to reflect the latest Oracle Linux Version.