### PR TITLE
fix: refactored file path handling, use AD number and other minor refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you don't have the required permissions and quota, contact your tenancy admin
 
 ## Deploy Using the Terraform CLI
 
-### Clone the Module
+### Clone the Repository
 Now, you'll want a local copy of this repo. You can make that with the commands:
 
     git clone https://github.com/oracle-quickstart/oci-arch-web-ha.git
@@ -51,10 +51,10 @@ tenancy_ocid         = "<tenancy_ocid>"
 user_ocid            = "<user_ocid>"
 fingerprint          = "<finger_print>"
 private_key_path     = "<pem_private_key_path>"
+private_key_password = "<pem_private_key_password>"
 
 # SSH Keys
-ssh_public_key  = "<public_ssh_key_path>"
-ssh_private_key  = "<private_ssh_key_path>"
+ssh_public_key_path  = "<public_ssh_key_path>"
 
 # database
 ATP_password           = "<ATP_user_password>"
@@ -64,12 +64,11 @@ ATP_data_guard_enabled = false # set the value to true only when you want to ena
 region = "<oci_region>"
 
 # Availablity Domain 
-availablity_domain_name = "<availablity_domain_name>"
+availablity_domain = "<availablity_domain_number>"
 
 # Compartment
 compartment_ocid = "<compartment_ocid>"
-
-````
+```
 
 ### Create the Resources
 Run the following commands:
@@ -86,4 +85,3 @@ When you no longer need the deployment, you can run this command to destroy the 
 ## Architecture Diagram
 
 ![](./images/web-app-diagram.png)
-

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ region = "<oci_region>"
 
 # Availablity Domain 
 availablity_domain = "<availablity_domain_number>"
+### USE ONE ^ OR THE OTHER v
+availability_domain_name = "<availability_domain_name>"
 
 # Compartment
 compartment_ocid = "<compartment_ocid>"
@@ -81,6 +83,41 @@ Run the following commands:
 When you no longer need the deployment, you can run this command to destroy the resources:
 
     terraform destroy
+
+## Deploy as a Module
+It's possible to utilize this as a module, providing the necessary inputs:
+
+```
+module "ha-web" {
+  source               = "
+  # Authentication
+  tenancy_ocid         = "<tenancy_ocid>"
+  user_ocid            = "<user_ocid>"
+  fingerprint          = "<finger_print>"
+  private_key          = "<contents_of_private_key>"
+  ### USE ONE ^ OR THE OTHER v
+  private_key_path     = "<pem_private_key_path>"
+  private_key_password = "<pem_private_key_password>"
+
+  # SSH Keys
+  ssh_public_key       = "<contents_of_public_ssh_key>"
+  ### USE ONE ^ OR THE OTHER v
+  ssh_public_key_path  = "<public_ssh_key_path>"
+
+  # database
+  ATP_password           = "<ATP_user_password>"
+  ATP_data_guard_enabled = false # set the value to true only when you want to enable standby and then re-run terraform apply
+
+  # Region
+  region = "<oci_region>"
+
+  # Availablity Domain 
+  availablity_domain = "<availablity_domain_number>"
+
+  # Compartment
+  compartment_ocid = "<compartment_ocid>"
+}
+```
 
 ## Architecture Diagram
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ It's possible to utilize this as a module, providing the necessary inputs:
 
 ```
 module "ha-web" {
-  source               = "
+  source               = "<git repo URL>"
+  
   # Authentication
   tenancy_ocid         = "<tenancy_ocid>"
   user_ocid            = "<user_ocid>"

--- a/compute.tf
+++ b/compute.tf
@@ -54,7 +54,7 @@ resource "oci_core_instance" "compute_instance1" {
   }
 
   metadata = {
-    ssh_authorized_keys = file(var.ssh_public_key_path)
+    ssh_authorized_keys = local.ssh_public_key
     user_data = data.template_cloudinit_config.cloud_init.rendered
   }
 
@@ -96,7 +96,7 @@ resource "oci_core_instance" "compute_instance2" {
   }
 
   metadata = {
-    ssh_authorized_keys = file(var.ssh_public_key_path)
+    ssh_authorized_keys = local.ssh_public_key
     user_data = data.template_cloudinit_config.cloud_init.rendered
   }
 

--- a/database.tf
+++ b/database.tf
@@ -16,6 +16,9 @@ resource "oci_database_autonomous_database" "ATPdatabase" {
   subnet_id                = var.ATP_private_endpoint ? oci_core_subnet.subnet_3.id : null
   is_data_guard_enabled    = var.ATP_data_guard_enabled
   defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }
 
 resource "random_string" "wallet_password" {

--- a/lb.tf
+++ b/lb.tf
@@ -7,7 +7,10 @@ locals {
 
 resource "oci_load_balancer" "lb1" {
   shape          = var.lb_shape
-
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
+  
   dynamic "shape_details" {
     for_each = local.is_flexible_lb_shape ? [1] : []
     content {

--- a/natgateway.tf
+++ b/natgateway.tf
@@ -2,8 +2,11 @@
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
 resource "oci_core_nat_gateway" "nat_gw" {
-    compartment_id = var.compartment_ocid
-    display_name = "nat_gateway"
-    vcn_id = oci_core_virtual_network.vcn.id
-    defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  compartment_id = var.compartment_ocid
+  display_name = "nat_gateway"
+  vcn_id = oci_core_virtual_network.vcn.id
+  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }

--- a/nsg.tf
+++ b/nsg.tf
@@ -3,133 +3,145 @@
 
 # ATPSecurityGroup
 resource "oci_core_network_security_group" "ATPSecurityGroup" {
-    compartment_id = var.compartment_ocid
-    display_name = "ATPSecurityGroup"
-    vcn_id = oci_core_virtual_network.vcn.id
-    defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  compartment_id = var.compartment_ocid
+  display_name = "ATPSecurityGroup"
+  vcn_id = oci_core_virtual_network.vcn.id
+  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }
 
 # Rules related to ATPSecurityGroup
 # EGRESS
 resource "oci_core_network_security_group_security_rule" "ATPSecurityEgressGroupRule" {
-    network_security_group_id = oci_core_network_security_group.ATPSecurityGroup.id
-    direction = "EGRESS"
-    protocol = "6"
-    destination = "10.0.1.0/24"
-    destination_type = "CIDR_BLOCK"
+  network_security_group_id = oci_core_network_security_group.ATPSecurityGroup.id
+  direction = "EGRESS"
+  protocol = "6"
+  destination = "10.0.1.0/24"
+  destination_type = "CIDR_BLOCK"
 }
 # INGRESS
 resource "oci_core_network_security_group_security_rule" "ATPSecurityIngressGroupRules" {
-    network_security_group_id = oci_core_network_security_group.ATPSecurityGroup.id
-    direction = "INGRESS"
-    protocol = "6"
-    source = "10.0.1.0/24"
-    source_type = "CIDR_BLOCK"
-    tcp_options {
-        destination_port_range {
-            max = 1522
-            min = 1522
-        }
+  network_security_group_id = oci_core_network_security_group.ATPSecurityGroup.id
+  direction = "INGRESS"
+  protocol = "6"
+  source = "10.0.1.0/24"
+  source_type = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      max = 1522
+      min = 1522
     }
+  }
 }
 
 # WebSecurityGroup
 resource "oci_core_network_security_group" "WebSecurityGroup" {
-    compartment_id = var.compartment_ocid
-    display_name = "WebSecurityGroup"
-    vcn_id = oci_core_virtual_network.vcn.id
-    defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  compartment_id = var.compartment_ocid
+  display_name = "WebSecurityGroup"
+  vcn_id = oci_core_virtual_network.vcn.id
+  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }
 # Rules related to WebSecurityGroup
 # EGRESS
 resource "oci_core_network_security_group_security_rule" "WebSecurityEgressATPGroupRule" {
-    network_security_group_id = oci_core_network_security_group.WebSecurityGroup.id
-    direction = "EGRESS"
-    protocol = "6"
-    destination = oci_core_network_security_group.ATPSecurityGroup.id 
-    destination_type = "NETWORK_SECURITY_GROUP"
+  network_security_group_id = oci_core_network_security_group.WebSecurityGroup.id
+  direction = "EGRESS"
+  protocol = "6"
+  destination = oci_core_network_security_group.ATPSecurityGroup.id 
+  destination_type = "NETWORK_SECURITY_GROUP"
 }
 resource "oci_core_network_security_group_security_rule" "WebSecurityEgressInternetGroupRule" {
-    network_security_group_id = oci_core_network_security_group.WebSecurityGroup.id
-    direction = "EGRESS"
-    protocol = "6"
-    destination = "10.0.0.0/24"
-    destination_type = "CIDR_BLOCK"
+  network_security_group_id = oci_core_network_security_group.WebSecurityGroup.id
+  direction = "EGRESS"
+  protocol = "6"
+  destination = "10.0.0.0/24"
+  destination_type = "CIDR_BLOCK"
 }
 # INGRESS
 resource "oci_core_network_security_group_security_rule" "WebSecurityIngressGroupRules" {
-    network_security_group_id = oci_core_network_security_group.WebSecurityGroup.id
-    direction = "INGRESS"
-    protocol = "6"
-    source = "10.0.0.0/24"
-    source_type = "CIDR_BLOCK"
-    tcp_options {
-        destination_port_range {
-            max = 5000
-            min = 5000
-        }
+  network_security_group_id = oci_core_network_security_group.WebSecurityGroup.id
+  direction = "INGRESS"
+  protocol = "6"
+  source = "10.0.0.0/24"
+  source_type = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      max = 5000
+      min = 5000
     }
+  }
 }
 
 # LBSecurityGroup
 resource "oci_core_network_security_group" "LBSecurityGroup" {
-    compartment_id = var.compartment_ocid
-    display_name = "LBSecurityGroup"
-    vcn_id = oci_core_virtual_network.vcn.id
-    defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  compartment_id = var.compartment_ocid
+  display_name = "LBSecurityGroup"
+  vcn_id = oci_core_virtual_network.vcn.id
+  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }
 # Rules related to LBSecurityGroup
 # EGRESS
 resource "oci_core_network_security_group_security_rule" "LBSecurityEgressInternetGroupRule" {
-    network_security_group_id = oci_core_network_security_group.LBSecurityGroup.id
-    direction = "EGRESS"
-    protocol = "6"
-    destination = "0.0.0.0/0"
-    destination_type = "CIDR_BLOCK"
+  network_security_group_id = oci_core_network_security_group.LBSecurityGroup.id
+  direction = "EGRESS"
+  protocol = "6"
+  destination = "0.0.0.0/0"
+  destination_type = "CIDR_BLOCK"
 }
 # INGRESS
 resource "oci_core_network_security_group_security_rule" "LBSecurityIngressGroupRules" {
-    network_security_group_id = oci_core_network_security_group.LBSecurityGroup.id
-    direction = "INGRESS"
-    protocol = "6"
-    source = "0.0.0.0/0"
-    source_type = "CIDR_BLOCK"
-    tcp_options {
-        destination_port_range {
-            max = 80
-            min = 80
-        }
+  network_security_group_id = oci_core_network_security_group.LBSecurityGroup.id
+  direction = "INGRESS"
+  protocol = "6"
+  source = "0.0.0.0/0"
+  source_type = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      max = 80
+      min = 80
     }
+  }
 }
 
 # SSHSecurityGroup
 resource "oci_core_network_security_group" "SSHSecurityGroup" {
-    compartment_id = var.compartment_ocid
-    display_name = "SSHSecurityGroup"
-    vcn_id = oci_core_virtual_network.vcn.id
-    defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  compartment_id = var.compartment_ocid
+  display_name = "SSHSecurityGroup"
+  vcn_id = oci_core_virtual_network.vcn.id
+  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }
 # Rules related to SSHSecurityGroup
 # EGRESS
 resource "oci_core_network_security_group_security_rule" "SSHSecurityEgressGroupRule" {
-    network_security_group_id = oci_core_network_security_group.SSHSecurityGroup.id
-    direction = "EGRESS"
-    protocol = "6"
-    destination = "0.0.0.0/0"
-    destination_type = "CIDR_BLOCK"
+  network_security_group_id = oci_core_network_security_group.SSHSecurityGroup.id
+  direction = "EGRESS"
+  protocol = "6"
+  destination = "0.0.0.0/0"
+  destination_type = "CIDR_BLOCK"
 }
 # INGRESS
 resource "oci_core_network_security_group_security_rule" "SSHSecurityIngressGroupRules" {
-    network_security_group_id = oci_core_network_security_group.SSHSecurityGroup.id
-    direction = "INGRESS"
-    protocol = "6"
-    source = "0.0.0.0/0"
-    source_type = "CIDR_BLOCK"
-    tcp_options {
-        destination_port_range {
-            max = 22
-            min = 22
-        }
+  network_security_group_id = oci_core_network_security_group.SSHSecurityGroup.id
+  direction = "INGRESS"
+  protocol = "6"
+  source = "0.0.0.0/0"
+  source_type = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      max = 22
+      min = 22
     }
+  }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,4 +4,5 @@ output "loadbalancer_public_url" {
 
 output "generated_ssh_private_key" {
   value = tls_private_key.public_private_key_pair.private_key_pem
+  sensitive = true
 }

--- a/provider.tf
+++ b/provider.tf
@@ -6,6 +6,7 @@ provider "oci" {
   user_ocid            = var.user_ocid
   fingerprint          = var.fingerprint
   private_key_path     = var.private_key_path
+  private_key_password = var.private_key_password
   region               = var.region
   disable_auto_retries = "true"
 }
@@ -16,6 +17,7 @@ provider "oci" {
   user_ocid            = var.user_ocid
   fingerprint          = var.fingerprint
   private_key_path     = var.private_key_path
+  private_key_password = var.private_key_password
   region               = data.oci_identity_region_subscriptions.home_region_subscriptions.region_subscriptions[0].region_name
   disable_auto_retries = "true"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,22 +2,30 @@
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
 provider "oci" {
+  region               = var.region
   tenancy_ocid         = var.tenancy_ocid
+  
+  #### BEGIN COMMENT OUT FOR USAGE ON ORM AND/OR CLOUD SHELL
   user_ocid            = var.user_ocid
   fingerprint          = var.fingerprint
-  private_key_path     = var.private_key_path
+  private_key          = local.private_key
   private_key_password = var.private_key_password
-  region               = var.region
+  #### END COMMENT OUT FOR USAGE ON ORM AND/OR CLOUD SHELL
+  
   disable_auto_retries = "true"
 }
 
 provider "oci" {
   alias                = "homeregion"
+  region               = data.oci_identity_region_subscriptions.home_region_subscriptions.region_subscriptions[0].region_name
   tenancy_ocid         = var.tenancy_ocid
+  
+  #### BEGIN COMMENT OUT FOR USAGE ON ORM AND/OR CLOUD SHELL
   user_ocid            = var.user_ocid
   fingerprint          = var.fingerprint
-  private_key_path     = var.private_key_path
+  private_key          = local.private_key
   private_key_password = var.private_key_password
-  region               = data.oci_identity_region_subscriptions.home_region_subscriptions.region_subscriptions[0].region_name
+  #### END COMMENT OUT FOR USAGE ON ORM AND/OR CLOUD SHELL
+  
   disable_auto_retries = "true"
 }

--- a/remote.tf
+++ b/remote.tf
@@ -51,7 +51,7 @@ resource "null_resource" "compute-script1" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/static/css/"
+    source      = "${path.module}/flask_dir/static/css/"
     destination = "/home/opc/static/css"
   }
 
@@ -65,7 +65,7 @@ resource "null_resource" "compute-script1" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/static/img/"
+    source      = "${path.module}/flask_dir/static/img/"
     destination = "/home/opc/static/img"
   }
 
@@ -79,7 +79,7 @@ resource "null_resource" "compute-script1" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/templates/"
+    source      = "${path.module}/flask_dir/templates/"
     destination = "/home/opc/templates"
   }
 
@@ -93,7 +93,7 @@ resource "null_resource" "compute-script1" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/"
+    source      = "${path.module}/flask_dir/"
     destination = "/home/opc/"
   }
 
@@ -107,7 +107,7 @@ resource "null_resource" "compute-script1" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "db_scripts/"
+    source      = "${path.module}/db_scripts/"
     destination = "/home/opc/"
   }
 
@@ -253,7 +253,7 @@ resource "null_resource" "compute-script2" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/static/css/"
+    source      = "${path.module}/flask_dir/static/css/"
     destination = "/home/opc/static/css"
   }
 
@@ -267,7 +267,7 @@ resource "null_resource" "compute-script2" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/static/img/"
+    source      = "${path.module}/flask_dir/static/img/"
     destination = "/home/opc/static/img"
   }
 
@@ -281,7 +281,7 @@ resource "null_resource" "compute-script2" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/templates/"
+    source      = "${path.module}/flask_dir/templates/"
     destination = "/home/opc/templates"
   }
 
@@ -295,7 +295,7 @@ resource "null_resource" "compute-script2" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "flask_dir/"
+    source      = "${path.module}/flask_dir/"
     destination = "/home/opc/"
   }
 
@@ -309,7 +309,7 @@ resource "null_resource" "compute-script2" {
       agent       = false
       timeout     = "10m"
     }
-    source      = "db_scripts/"
+    source      = "${path.module}/db_scripts/"
     destination = "/home/opc/"
   }
 

--- a/route_tables.tf
+++ b/route_tables.tf
@@ -8,20 +8,27 @@ resource "oci_core_route_table" "rt-pub" {
   vcn_id         = oci_core_virtual_network.vcn.id
   display_name   = "rt-table-pub"
   route_rules {
-    cidr_block        = "0.0.0.0/0"
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
     network_entity_id = oci_core_internet_gateway.ig.id
   }
   defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }
 
 resource "oci_core_route_table" "rt-priv" {
-    compartment_id = var.compartment_ocid
-    vcn_id         = oci_core_virtual_network.vcn.id
-    display_name = "rt-table-priv"
-    route_rules {
-        destination       = "0.0.0.0/0"
-        destination_type  = "CIDR_BLOCK"
-        network_entity_id = oci_core_nat_gateway.nat_gw.id
-    }
-    defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_virtual_network.vcn.id
+  display_name = "rt-table-priv"
+  route_rules {
+      destination       = "0.0.0.0/0"
+      destination_type  = "CIDR_BLOCK"
+      network_entity_id = oci_core_nat_gateway.nat_gw.id
+  }
+  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+  ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+}
 }

--- a/schema.yaml
+++ b/schema.yaml
@@ -14,6 +14,13 @@
       - tenancy_ocid
       - region
       - release
+      - private_key
+      - private_key_path
+      - private_key_password
+      - availability_domain
+      - fingerprint
+      - user_ocid
+      - ssh_public_key_path
 
     - title: Required Configuration
       visible: true  
@@ -21,7 +28,7 @@
       - ATP_password
       - ATP_private_endpoint 
       - compartment_ocid
-      - availablity_domain_name
+      - availability_domain_name
       - show_advanced
 
     - title: Load Balancer Optional Configuration
@@ -85,7 +92,7 @@
         title: Region
         description: "Region where you want to deploy the resources defined by this stack."
 
-      availablity_domain_name:
+      availability_domain_name:
         type: oci:identity:availabilitydomain:name
         required: true
         visibile: true

--- a/subnets.tf
+++ b/subnets.tf
@@ -12,7 +12,10 @@ resource "oci_core_subnet" "subnet_1" {
   route_table_id    = oci_core_route_table.rt-pub.id
   dns_label         = "subnet1"
   defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
-
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
+  
   provisioner "local-exec" {
     command = "sleep 5"
   }
@@ -27,7 +30,10 @@ resource "oci_core_subnet" "subnet_2" {
   route_table_id    = oci_core_route_table.rt-pub.id
   dns_label         = "subnet2"
   defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
-
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
+  
   provisioner "local-exec" {
     command = "sleep 5"
   }
@@ -43,7 +49,10 @@ resource "oci_core_subnet" "subnet_3" {
   dns_label         = "subnet3"
   prohibit_public_ip_on_vnic = true
   defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
-
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
+  
   provisioner "local-exec" {
     command = "sleep 5"
   }

--- a/tags.tf
+++ b/tags.tf
@@ -6,29 +6,28 @@ resource "random_id" "tag" {
 }
 
 resource "oci_identity_tag_namespace" "ArchitectureCenterTagNamespace" {
-    provider = oci.homeregion
-    compartment_id = var.compartment_ocid
-    description = "ArchitectureCenterTagNamespace"
-    name = "ArchitectureCenter\\ha-web-app-${random_id.tag.hex}"
-  
-    provisioner "local-exec" {
-       command = "sleep 10"
-    }
+  provider = oci.homeregion
+  compartment_id = var.compartment_ocid
+  description = "ArchitectureCenterTagNamespace"
+  name = "ArchitectureCenter\\ha-web-app-${random_id.tag.hex}"
+
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
 }
 
 resource "oci_identity_tag" "ArchitectureCenterTag" {
-    provider = oci.homeregion
-    description = "ArchitectureCenterTag"
-    name = "release"
-    tag_namespace_id = oci_identity_tag_namespace.ArchitectureCenterTagNamespace.id
+  provider = oci.homeregion
+  description = "ArchitectureCenterTag"
+  name = "release"
+  tag_namespace_id = oci_identity_tag_namespace.ArchitectureCenterTagNamespace.id
 
-    validator {
-        validator_type = "ENUM"
-        values         = ["release", "1.1"]
-    }
+  validator {
+    validator_type = "ENUM"
+    values         = ["release", "1.1"]
+  }
 
-    provisioner "local-exec" {
-       command = "sleep 120"
-    }
-
+  provisioner "local-exec" {
+    command = "sleep 120"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,16 +7,17 @@ variable "compartment_ocid" {}
 variable "user_ocid" {}
 variable "fingerprint" {}
 variable "private_key_path" {}
+variable "private_key_password" {}
 variable "region" {}
 variable "ATP_password" {}
-variable "availablity_domain_name" {}
+variable "availability_domain" {}
 
 variable "release" {
   description = "Reference Architecture Release (OCI Architecture Center)"
   default     = "1.1"
 }
 
-variable "ssh_public_key" {
+variable "ssh_public_key_path" {
   default = ""
 }
 
@@ -116,4 +117,5 @@ locals {
 # Checks if is using Flexible Compute Shapes
 locals {
   is_flexible_node_shape = contains(local.compute_flexible_shapes, var.instance_shape)
+  availability_domain_name = lookup(data.oci_identity_availability_domains.ads.availability_domains[var.availability_domain],"name")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,20 +3,41 @@
 
 # Variables
 variable "tenancy_ocid" {}
-variable "compartment_ocid" {}
-variable "user_ocid" {}
-variable "fingerprint" {}
-variable "private_key_path" {}
-variable "private_key_password" {}
+variable "compartment_ocid" {
+  default = ""
+}
+variable "user_ocid" {
+  default = ""
+}
+variable "fingerprint" {
+  default = ""
+}
+variable "private_key" {
+  default = ""
+}
+variable "private_key_path" {
+  default = ""
+}
+variable "private_key_password" {
+  default = ""
+}
 variable "region" {}
 variable "ATP_password" {}
-variable "availability_domain" {}
+variable "availability_domain" {
+  default = ""
+}
+variable "availability_domain_name" {
+  default = ""
+}
 
 variable "release" {
   description = "Reference Architecture Release (OCI Architecture Center)"
   default     = "1.1"
 }
 
+variable "ssh_public_key" {
+  default = ""
+}
 variable "ssh_public_key_path" {
   default = ""
 }
@@ -106,16 +127,16 @@ variable  "ATP_data_guard_enabled" {
   default = false 
 }
 
-# Dictionary Locals
 locals {
+  # Dictionary Locals
   compute_flexible_shapes = [
     "VM.Standard.E3.Flex",
     "VM.Standard.E4.Flex"
   ]
-}
-
-# Checks if is using Flexible Compute Shapes
-locals {
+  # Checks if is using Flexible Compute Shapes
   is_flexible_node_shape = contains(local.compute_flexible_shapes, var.instance_shape)
-  availability_domain_name = lookup(data.oci_identity_availability_domains.ads.availability_domains[var.availability_domain],"name")
+  
+  availability_domain_name = var.availability_domain_name == "" ? lookup(data.oci_identity_availability_domains.ads.availability_domains[var.availability_domain],"name") : var.availability_domain_name
+  private_key = var.private_key == "" ? file(var.private_key_path) : var.private_key
+  ssh_public_key = var.ssh_public_key == "" ? file(var.ssh_public_key_path) : var.ssh_public_key
 }

--- a/vcn.tf
+++ b/vcn.tf
@@ -9,4 +9,7 @@ resource "oci_core_virtual_network" "vcn" {
   display_name   = "web-app-vcn"
   dns_label      = "tfexamplevcn"
   defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  lifecycle {
+    ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
+  }
 }


### PR DESCRIPTION
- Updated documentation (removed deprecated variables)
- Uses AD number (instead of name), doing a lookup of the name
- Minor reformatting (consistent tab stops)
- Added support for private key password
- Ignored `Oracle-Tags` tags
- Refactored file paths to use `path.module`